### PR TITLE
Use go v1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/advbet/uid
 
-go 1.18
+go 1.17
 
 require github.com/stretchr/testify v1.7.1
 


### PR DESCRIPTION
Go was downgraded to 1.17 as not all golangci-lint rules work on 1.18.